### PR TITLE
Make date_created and date_updated NOT NULL

### DIFF
--- a/flask_restutils/models.py
+++ b/flask_restutils/models.py
@@ -11,12 +11,13 @@ class BaseModelMixin(object):
 
     @declared_attr
     def date_created(cls):
-        return Column(DateTime, default=datetime.datetime.utcnow)
+        return Column(DateTime, default=datetime.datetime.utcnow,
+                      nullable=False)
 
     @declared_attr
     def date_updated(cls):
         return Column(DateTime, default=datetime.datetime.utcnow,
-                      onupdate=datetime.datetime.utcnow)
+                      onupdate=datetime.datetime.utcnow, nullable=False)
 
     def __repr__(self):
         if getattr(self, 'id', None):


### PR DESCRIPTION
Discovered this by trying to call `./manage.py db migrate` on the master branch in the main repo.

Alembic spotted that the `role` table's `date_created` and `date_updated` are `NOT NULL` (because of https://github.com/closeio/closeio/blob/fecd8a3ebfd9fcab6bbe3394aeca2b757a0e52a6/sql_migrations/helpers.py#L26), but their SQLA model (based on this repo's `BaseModelMixin`) defines them as nullable.

If we agree this is the way to go, I think some Dialer columns would have to be altered.