### PR TITLE
Allow Resource.get_queryset to return None

### DIFF
--- a/flask_restutils/helpers.py
+++ b/flask_restutils/helpers.py
@@ -27,7 +27,7 @@ def rollback_on_error(session):
         def wrapped(*args, **kwargs):
             try:
                 return func(*args, **kwargs)
-            except:
+            except Exception:
                 session.rollback()
                 raise
         return wrapped


### PR DESCRIPTION
Since SQLAlchemy doesn't have a method equivalent to MongoEngine's/Django's `QuerySet.none()`