### PR TITLE
Add RandomPKMixin.generate_id()

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ defaults: &defaults
   - run:
       name: Install dependencies
       command: |
+        sudo ln -s ~/.ssh /root/.ssh
         sudo pip install --no-deps -r requirements_tests.txt
         sudo pip install flake8 flake8-import-order pep8-naming
   - run:

--- a/flask_restutils/random_pk.py
+++ b/flask_restutils/random_pk.py
@@ -41,9 +41,13 @@ class RandomPKMixin(object):
         return Column(
             'id',
             RandomPKField(prefix),
-            default=lambda: uuid_to_id(uuid.uuid4(), prefix),
+            default=cls.generate_id,
             primary_key=True
         )
+
+    @classmethod
+    def generate_id(cls):
+        return uuid_to_id(uuid.uuid4(), cls.get_id_prefix())
 
     @classmethod
     def get_id_prefix(cls):

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -12,3 +12,4 @@ pytest==3.0.7
 six==1.10.0
 SQLAlchemy==1.1.6
 Werkzeug==0.12.1
+-e git+ssh://git@github.com/closeio/zbase62.git@e13d2c748ccdb0cafe6465961a0c6a4111ee219f#egg=zbase62

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ testpaths=tests
 
 [flake8]
 application-import-names=flask_restutils
-exclude=build,dist,docs,venv,.tox,.eggs
+exclude=build,dist,docs,src,venv,.tox,.eggs
 ignore=E261,N802,N805,N806
 import-order-style=google
 max-complexity=10

--- a/tests/test_restutils.py
+++ b/tests/test_restutils.py
@@ -5,6 +5,7 @@ from sqlalchemy import Column, Integer
 from sqlalchemy.orm.exc import StaleDataError
 
 from flask_restutils.models import VersionMixin
+from flask_restutils.random_pk import RandomPKMixin
 
 
 TEST_DB_URL = 'sqlite:///tmp/test_restutils.db'
@@ -50,3 +51,10 @@ class TestRestutils:
         v2 = other_session.query(VersionTest).get(v.id)
         v2.value = 2
         sql.session.commit()
+
+    def test_random_pk_generate_id(self):
+        class MyModel(RandomPKMixin):
+            class Meta:
+                id_prefix = 'mymodel'
+
+        assert MyModel.generate_id().startswith('mymodel_')


### PR DESCRIPTION
Added a test which required this module which required `zbase62` which fails on python 3. But it passes on 2.7 which is all that matters for now.

I had to symlink the `.ssh` creds injected for the circle user to the `root` user for `pip install` to succeed.