### PR TITLE
Support bulk PUT

### DIFF
--- a/flask_restutils/resources.py
+++ b/flask_restutils/resources.py
@@ -1,6 +1,7 @@
 from cleancat import ValidationError
 from flask import request
 from flask_restful import abort, Resource
+from werkzeug.exceptions import MethodNotAllowed
 
 from .helpers import get_db, request_json
 
@@ -93,7 +94,10 @@ class ModelBasedResource(Resource):
         schema = Schema(data=Schema.obj_to_dict(obj))
         return schema.serialize(), 201
 
-    def put(self, pk):
+    def put(self, pk=None):
+        if pk is None:
+            return self.bulk_put()
+
         obj = self.get_object(pk)
         if obj is None:
             abort(404)
@@ -120,6 +124,10 @@ class ModelBasedResource(Resource):
 
         schema = Schema(data=Schema.obj_to_dict(obj))
         return schema.serialize(), 200
+
+    def bulk_put(self):
+        # Override this method in a subclass if you want to support bulk PUT.
+        raise MethodNotAllowed
 
     def delete(self, pk):
         obj = self.get_object(pk)


### PR DESCRIPTION
1. Make `pk` optional in `ModelBasedResource.put`.
2. If `pk` is indeed not passed, redirect the flow to `ModelBasedResource.bulk_put`.
3. Raise `MethodNotAllowed` by default.